### PR TITLE
Separate classification functions & leave one run out 

### DIFF
--- a/mvpa.m
+++ b/mvpa.m
@@ -38,23 +38,28 @@ classdef mvpa
             end
         end
         function factor = collate_factor_labels(factor, emat, session, run)
-            % collate factors across sessions and runs
-
-            for f = 1:(length(factor)-3)
-                factor(f).classlabels = cat(1, factor(f).classlabels, factor(f).labels(emat(:,factor(f).col))');
+            % lowercase labels
+            for f = 1:length(factor)
+                factor(f).labels = lower(factor(f).labels);
             end
-            % collates the factor that is a combination of all other
-            % factors
-            for c = 1:size(emat,1)
-                tmp = factor(1).classlabels{c};
-                for f = 1:(length(factor)-3)
-                    str{c} = strcat(tmp, factor(f).classlabels{c});
+            % collate factors across sessions and runs
+            for f = 1:length(factor)
+                if ~isnan(factor(f).col)
+                    factor(f).classlabels = lower(cat(1, factor(f).classlabels, factor(f).labels(emat(:,factor(f).col))'));
+                elseif strcmp(factor(f).labels, 'combo')
+                    for c = 1:size(emat,1)
+                        tmp = factor(1).classlabels{c};
+                        for f2 = 1:(f-1)
+                            str{c} = lower(strcat(tmp, factor(f2).classlabels{c}));
+                        end
+                    end
+                    factor(f).classlabels = cat(2, factor(f).classlabels, str);
+                elseif strcmp(factor(f).labels, 'session')
+                    factor(f).classlabels = cat(1, factor(f).classlabels, session.*ones(size(emat,1), 1));
+                elseif strcmp(factor(f).labels, 'run')
+                    factor(f).classlabels = cat(1, factor(f).classlabels, run.*ones(size(emat,1), 1));
                 end
             end
-            factor(end-2).classlabels = cat(2, factor(end-2).classlabels, str);
-            % make session and run factors
-            factor(end-1).classlabels = cat(1, factor(end-1).classlabels, session.*ones(size(emat,1), 1));
-            factor(end).classlabels = cat(1, factor(end).classlabels, run.*ones(size(emat,1), 1));
         end
 
         % subsetting
@@ -74,9 +79,9 @@ classdef mvpa
                 if isa(model.add_pred{p}, 'double')
                     predictors = cat(2, predictors, factor(model.add_pred{p}).classlabels);
                 elseif strcmp(model.add_pred{p}, 'session')
-                    predictors = cat(2, predictors, num2cell(factor(end-1).classlabels));
+                    predictors = cat(2, predictors, num2cell(single(factor(end-1).classlabels)));
                 elseif strcmp(model.add_pred{p}, 'run')
-                    predictors = cat(2, predictors, num2cell(factor(end).classlabels));
+                    predictors = cat(2, predictors, num2cell(single(factor(end).classlabels)));
                 end
             end
         end
@@ -89,7 +94,7 @@ classdef mvpa
             end
             predictors = predictors(find(idx), :);
         end
-            % from anatomies to voi 
+        % from anatomies to voi 
         function [b] = VMPinVOI(vmp, voi, voiNum)
             % [b] = GLMinVOI(vmp, voi ,voiNum)
             %
@@ -295,14 +300,14 @@ classdef mvpa
             end
         end
 
-
         function [perf, Mdl, Mdl_CV] = classify(model,predictors,classlabels, genlabels)
+            
             if ~sum(strcmp(model.CVstyle, 'Generalize'))
                 train_idx = 1:length(classlabels);
                 test_idx = train_idx;
             else
-                train_idx = strcmp(genlabels, model.CVstyle{3});
-                test_idx = strcmp(genlabels, model.CVstyle{4});
+                train_idx = strcmpi(genlabels, model.CVstyle{3}); 
+                test_idx = strcmpi(genlabels, model.CVstyle{4});
             end
             if strcmp(model.desc{1}, 'DiscrimType')
                 Mdl = fitcdiscr(predictors(train_idx, :), classlabels(train_idx), model.desc{:});
@@ -321,6 +326,140 @@ classdef mvpa
                 perf.std = 0;
             end
         end
+        
+        % separate things out (for flexibility)
+        
+        % select cv sets while allowing for cross-condition decoding
+        function [cv, doi, doiPredictors] = select_train_test(model, factor, predictors)
+            
+            % housekeeping
+            trainConds = lower(model.trainConds);
+            testConds = lower(model.testConds);
+            
+            % find factor of interest
+            if ~isempty(trainConds)
+                for f = 1:length(factor)
+                    for tc = 1:length(trainConds)
+                        temp = strfind(factor(f).labels, trainConds(tc));
+                        trainTemp(f,tc) = sum([temp{:}]);
+                    end
+                end
+                [trainr,~] = find(trainTemp==1);
+                if length(unique(trainr)) > 1
+                    error('error: trainConds; can only do within a factor for now');
+                else
+                    [trainFactor, ~] = find(trainTemp(:,1)==1);
+                end
+            end
+            if ~isempty(testConds)
+                for f = 1:length(factor)
+                    for tc = 1:length(testConds)
+                        temp = strfind(factor(f).labels, testConds(tc));
+                        testTemp(f,tc) = sum([temp{:}]);
+                    end
+                end
+                [testr,~] = find(testTemp==1);
+                if length(unique(testr)) > 1
+                    error('error: testConds; can only do within a factor for now');
+                else
+                    [testFactor, ~] = find(testTemp(:,1)==1);
+                end
+            end
+            if trainFactor ~= testFactor
+                error('error: Can only generalize across conditions within a factor for now');
+            end
+            
+            % extract data of interest 
+            loi = unique([trainConds testConds]); 
+            for l = 1:length(loi)
+                tempidx(:,l) = strcmp(factor(trainFactor).classlabels, loi(l)); 
+            end
+            idx = logical(sum(tempidx,2));
+            doiPredictors = predictors(idx,:); 
+            doi = factor;
+            for f = 1:length(factor)
+                doi(f).doilabels = factor(f).classlabels(idx);
+            end
+            
+            % figure out number of runs (combination of runs and sessions)
+            sessrun = unique([factor(end-1).classlabels factor(end).classlabels], 'rows');
+            nruns = size(sessrun,1);
+            
+            % select train and test data
+            if ~strcmp(model.CVstyle{1}, 'Generalize') && ~strcmp(model.CVstyle{1}, 'LeaveOneRunOut') 
+                disp('Using default function to partition');
+                if length(testConds) ~= length(trainConds) || ~all(strcmp(sort(testConds),sort(trainConds)))
+                    error('error: model.CVstyle; Default parittion not possible. Use LeaveOneOut');
+                end
+                % partition using default matlab function (e.g. kfold, holdout, ...)
+                cv = cvpartition(doi(model.class_factor).doilabels, model.CVstyle{:});
+            else % 
+                disp('Leave one run out');
+                cv.NumObservations = length(doi(1).doilabels);
+                cv.NumTestSets = nruns;
+                cv.test = @(x) mvpa.LeaveOneRunOut_test(x,doi,sessrun,testConds,testFactor);
+                cv.training = @(x) mvpa.LeaveOneRunOut_train(x,doi,sessrun,trainConds,trainFactor);
+                cv.TestSize = arrayfun(@(x) sum(cv.test(x)), 1:nruns);
+                cv.TrainSize = arrayfun(@(x) sum(cv.training(x)), 1:nruns);
+            end
+
+        end
+        
+        % Leave-One-Run-Out test
+        function test_idx = LeaveOneRunOut_test(run,doi,sessrun,testConds,testFactor)
+            % test idx
+            for ci = 1:length(testConds)
+                tempidx(:,ci) = (doi(end-1).doilabels == sessrun(run,1)) & (doi(end).doilabels == sessrun(run,2)) & ...
+                    strcmp(doi(testFactor).doilabels,testConds{ci});
+            end
+            test_idx = logical(sum(tempidx,2)); 
+        end
+        
+        % Leave-One-Run-Out train
+        function train_idx = LeaveOneRunOut_train(run,doi,sessrun,trainConds,trainFactor)
+            temp = [doi(end-1).doilabels doi(end).doilabels];
+            whichruns_temp = (temp~=[sessrun(run,1) sessrun(run,2)]);
+            whichruns = or(whichruns_temp(:,1), whichruns_temp(:,2));
+            % training idx
+            for ci = 1:length(trainConds)
+                tempidx(:,ci) = whichruns & strcmp(doi(trainFactor).doilabels,trainConds{ci});
+            end
+            train_idx = logical(sum(tempidx,2));
+        end
+        
+        % train
+        function [Mdl] = train(model, predictors, labels)
+
+            if strcmp(model.desc{1}, 'DiscrimType')
+                Mdl = fitcdiscr(predictors, labels, model.desc{:});
+            elseif strcmp(model.desc{1},'SVM')
+                Mdl = fitcecoc(predictors, labels, model.desc{:});
+            end
+            
+        end
+        
+        % test
+        function predlabels = test(Mdl, testpredictors)
+            
+            predlabels = Mdl.predict(testpredictors);
+%             predlabels = predict(Mdl, testpredictors);
+            
+        end
+        
+        % output
+        function perf = output(testlabels, predlabels)
+            
+            perf.testlabels = testlabels;
+            perf.predlabels = predlabels;
+            
+            temp = strcmp(testlabels, predlabels);
+            
+            perf.mean = mean(temp);
+            perf.std = std(temp);
+            perf.sem = perf.std/sqrt(length(testlabels));
+        
+        end
+        
     end
 end
 

--- a/mvpa.m
+++ b/mvpa.m
@@ -39,19 +39,18 @@ classdef mvpa
                 end
             end
         end
-<<<<<<< HEAD
         function factor = collate_factor_labels(factor, conds, session, run)
             % collate factors across sessions and runs
-            
+
             if length(factor)>3 % if we have more than one factor, there's a combination factor
-                nf = 3; 
+                nf = 3;
             else % if only one explicitly defined factor, we just have 3 factors, the factor, session and run
                 nf = 2;
             end
             for f = 1:(length(factor)-nf)
                 factor(f).classlabels = cat(1, factor(f).classlabels, factor(f).labels(conds(:,factor(f).col))');
             end
-            if length(factor)>3 
+            if length(factor)>3
                 % collates the factor that is a combination of all other
                 % factors
                 for c = 1:size(conds,1)
@@ -59,38 +58,12 @@ classdef mvpa
                     for f = 1:(length(factor)-3)
                         str{c} = strcat(tmp, factor(f).classlabels{c});
                     end
-=======
-        function factor = collate_factor_labels(factor, emat, session, run)
-            % lowercase labels
-            for f = 1:length(factor)
-                factor(f).labels = lower(factor(f).labels);
-            end
-            % collate factors across sessions and runs
-            for f = 1:length(factor)
-                if ~isnan(factor(f).col)
-                    factor(f).classlabels = lower(cat(1, factor(f).classlabels, factor(f).labels(emat(:,factor(f).col))'));
-                elseif strcmp(factor(f).labels, 'combo')
-                    for c = 1:size(emat,1)
-                        tmp = factor(1).classlabels{c};
-                        for f2 = 1:(f-1)
-                            str{c} = lower(strcat(tmp, factor(f2).classlabels{c}));
-                        end
-                    end
-                    factor(f).classlabels = cat(2, factor(f).classlabels, str);
-                elseif strcmp(factor(f).labels, 'session')
-                    factor(f).classlabels = cat(1, factor(f).classlabels, session.*ones(size(emat,1), 1));
-                elseif strcmp(factor(f).labels, 'run')
-                    factor(f).classlabels = cat(1, factor(f).classlabels, run.*ones(size(emat,1), 1));
->>>>>>> developClassify
                 end
                 factor(end-2).classlabels = cat(2, factor(end-2).classlabels, str);
             end
-<<<<<<< HEAD
             % make session and run factors
             factor(end-1).classlabels = cat(1, factor(end-1).classlabels, session.*ones(size(conds,1), 1));
             factor(end).classlabels = cat(1, factor(end).classlabels, run.*ones(size(conds,1), 1));
-=======
->>>>>>> developClassify
         end
 
         % subsetting
@@ -102,7 +75,7 @@ classdef mvpa
                 data_roi = mvpa.GLMinVOI(data_xff, roi_xff);% get the beta weights by roi
             end
         end
-        
+
         function [predictors] = generate_predictors(model, factor, roi)
             % so decide what besides the voxel values will be predictors
             predictors = num2cell(roi.predictors);
@@ -125,7 +98,7 @@ classdef mvpa
             end
             predictors = predictors(find(idx), :);
         end
-        % from anatomies to voi 
+        % from anatomies to voi
         function [b] = VMPinVOI(vmp, voi, voiNum)
             % [b] = GLMinVOI(vmp, voi ,voiNum)
             %
@@ -332,12 +305,12 @@ classdef mvpa
         end
 
         function [perf, Mdl, Mdl_CV] = classify(model,predictors,classlabels, genlabels)
-            
+
             if ~sum(strcmp(model.CVstyle, 'Generalize'))
                 train_idx = 1:length(classlabels);
                 test_idx = train_idx;
             else
-                train_idx = strcmpi(genlabels, model.CVstyle{3}); 
+                train_idx = strcmpi(genlabels, model.CVstyle{3});
                 test_idx = strcmpi(genlabels, model.CVstyle{4});
             end
             if strcmp(model.desc{1}, 'DiscrimType')
@@ -357,22 +330,22 @@ classdef mvpa
                 perf.std = 0;
             end
         end
-<<<<<<< HEAD
 
-
- 
-
-=======
-        
         % separate things out (for flexibility)
-        
+
         % select cv sets while allowing for cross-condition decoding
         function [cv, doi, doiPredictors] = select_train_test(model, factor, predictors)
-            
+
             % housekeeping
             trainConds = lower(model.trainConds);
             testConds = lower(model.testConds);
             
+            % if not already, lowercase labels, just to make it easier
+            for f = 1:length(factor)
+                factor(f).labels = lower(factor(f).labels);
+                factor(f).classlabels = lower(factor(f).classlabels);
+            end
+
             % find factor of interest
             if ~isempty(trainConds)
                 for f = 1:length(factor)
@@ -405,32 +378,32 @@ classdef mvpa
             if trainFactor ~= testFactor
                 error('error: Can only generalize across conditions within a factor for now');
             end
-            
-            % extract data of interest 
-            loi = unique([trainConds testConds]); 
+
+            % extract data of interest
+            loi = unique([trainConds testConds]);
             for l = 1:length(loi)
-                tempidx(:,l) = strcmp(factor(trainFactor).classlabels, loi(l)); 
+                tempidx(:,l) = strcmpi(factor(trainFactor).classlabels, loi(l));
             end
             idx = logical(sum(tempidx,2));
-            doiPredictors = predictors(idx,:); 
+            doiPredictors = predictors(idx,:);
             doi = factor;
             for f = 1:length(factor)
                 doi(f).doilabels = factor(f).classlabels(idx);
             end
-            
+
             % figure out number of runs (combination of runs and sessions)
             sessrun = unique([factor(end-1).classlabels factor(end).classlabels], 'rows');
             nruns = size(sessrun,1);
-            
+
             % select train and test data
-            if ~strcmp(model.CVstyle{1}, 'Generalize') && ~strcmp(model.CVstyle{1}, 'LeaveOneRunOut') 
+            if ~strcmp(model.CVstyle{1}, 'Generalize') && ~strcmp(model.CVstyle{1}, 'LeaveOneRunOut')
                 disp('Using default function to partition');
                 if length(testConds) ~= length(trainConds) || ~all(strcmp(sort(testConds),sort(trainConds)))
                     error('error: model.CVstyle; Default parittion not possible. Use LeaveOneOut');
                 end
                 % partition using default matlab function (e.g. kfold, holdout, ...)
                 cv = cvpartition(doi(model.class_factor).doilabels, model.CVstyle{:});
-            else % 
+            else %
                 disp('Leave one run out');
                 cv.NumObservations = length(doi(1).doilabels);
                 cv.NumTestSets = nruns;
@@ -441,7 +414,7 @@ classdef mvpa
             end
 
         end
-        
+
         % Leave-One-Run-Out test
         function test_idx = LeaveOneRunOut_test(run,doi,sessrun,testConds,testFactor)
             % test idx
@@ -449,9 +422,9 @@ classdef mvpa
                 tempidx(:,ci) = (doi(end-1).doilabels == sessrun(run,1)) & (doi(end).doilabels == sessrun(run,2)) & ...
                     strcmp(doi(testFactor).doilabels,testConds{ci});
             end
-            test_idx = logical(sum(tempidx,2)); 
+            test_idx = logical(sum(tempidx,2));
         end
-        
+
         % Leave-One-Run-Out train
         function train_idx = LeaveOneRunOut_train(run,doi,sessrun,trainConds,trainFactor)
             temp = [doi(end-1).doilabels doi(end).doilabels];
@@ -463,7 +436,7 @@ classdef mvpa
             end
             train_idx = logical(sum(tempidx,2));
         end
-        
+
         % train
         function [Mdl] = train(model, predictors, labels)
 
@@ -472,32 +445,30 @@ classdef mvpa
             elseif strcmp(model.desc{1},'SVM')
                 Mdl = fitcecoc(predictors, labels, model.desc{:});
             end
-            
+
         end
-        
+
         % test
         function predlabels = test(Mdl, testpredictors)
-            
+
             predlabels = Mdl.predict(testpredictors);
 %             predlabels = predict(Mdl, testpredictors);
-            
+
         end
-        
+
         % output
         function perf = output(testlabels, predlabels)
-            
+
             perf.testlabels = testlabels;
             perf.predlabels = predlabels;
-            
+
             temp = strcmp(testlabels, predlabels);
-            
+
             perf.mean = mean(temp);
             perf.std = std(temp);
             perf.sem = perf.std/sqrt(length(testlabels));
-        
+
         end
-        
->>>>>>> developClassify
+
     end
 end
-

--- a/mvpa_tutorial_LeaveOneRunOut.m
+++ b/mvpa_tutorial_LeaveOneRunOut.m
@@ -1,0 +1,174 @@
+% run MVPA using MVPA UW toolbox
+% tutorial written by WJP 02/2022
+
+clear all;
+
+%% dependencies
+
+% in addition to Neuroelf:
+addpath('/Users/woonjupark/Dropbox/[WP]/[Projects]/Tools/MVPA_UW_Toolbox');
+
+%% directories
+
+paths.main = {'/Volumes/viscog.ibic.washington.edu/WoonJuPark/MT/MTPilotTask'};
+paths.subject = {'sub-NS_G_RQ_1982'};
+
+%% load ROI (aka .voi files)
+
+roi(1).name = {'rPT'}; 
+roi(2).name = {'lMT'}; 
+roi(3).name = {'rMT'};
+
+paths.roi = {'rois'}; % where are the roi files located inside the subject directory
+for run = 1:length(roi)
+    roi(run).predictors = [];
+end % initialize the roi struct to collate later 
+
+%% load beta weights
+
+paths.session = fullfile(paths.main, paths.subject, {'ses-02', 'ses-03'});
+
+%% define if using vmp or glm BOLD data
+
+% dataformat = 'vmp';
+% paths.data = fullfile('derivatives', '*_GLM_trials.vmp');
+dataformat = 'glm';
+paths.data = fullfile('derivatives', '*_glm_trials_ver2.glm'); % where the data files are located inside the subject directory
+
+%% setup experimental condition lists
+% make sure to add 'session' and 'run', as some of the info are used in other functions
+
+factor(1).col = 2; 
+factor(1).labels = {'Seq', 'Onset', 'Random'}; 
+factor(1).chance = 1/3;
+
+factor(2).col = 3; 
+factor(2).labels =  {'left', 'right'}; 
+factor(2).chance = 1/2;
+
+factor(3).col = NaN; 
+factor(3).labels = {'combo'}; 
+factor(3).chance = 1/6; % combines the other factors
+
+factor(4).col = NaN; 
+factor(4).labels = {'session'}; 
+factor(4).chance = NaN; % records session
+
+factor(5).col = NaN; 
+factor(5).labels = {'run'}; 
+factor(5).chance = NaN; % records run
+
+for f = 1:length(factor)
+    factor(f).classlabels = [];
+end % initialize the factors to collate later 
+
+%% collect all the rois
+
+voiFile = fullfile(paths.main, paths.subject,paths.roi,{[paths.subject{1}, '_undist_rois.voi']});
+roi_xff = mvpa.load_roi(voiFile{1}); % load the rois
+
+for sess = 1:length(paths.session) % for each session
+    cond_filelist = dir(fullfile(paths.session{sess},'*task*.mat')); % each experimental condition file
+    data_filelist = dir(fullfile(paths.session{sess}, paths.data)); % each data file
+    if length(cond_filelist)~=length(data_filelist)
+        error(['number of condition files ', num2str(length(cond_filelist)), ...
+            ' does not match the number of experimental files', num2str(length(data_filelist))]);
+    end
+    for run = 1:length(data_filelist) % for each vmp/glm file
+
+        % deal with factors 
+        conds = mvpa.load_exp(cond_filelist(run)); % load exp protocols
+        factor = mvpa.collate_factor_labels(factor, cell2mat(conds.mat), sess, run); % save the class labels and make everything lowercase
+        
+        % deal with data
+        data_xff = mvpa.load_data(data_filelist(run)); % load in vmp or glm
+        data_roi = mvpa.subset_data_rois(data_xff, roi_xff, dataformat); % just save the data for ROIs, in a temp structure
+        roi = mvpa.collate_roi_predictors(roi, data_roi, dataformat); % now collate the roi data, over all the runs
+    end
+end
+
+
+%% classify L/R using Leave One Run Out procedure for cross validation
+
+model(1).desc = {'DiscrimType', 'linear', 'OptimizeHyperparameters', 'none'};
+model(1).class_factor = 2; % which factor are you trying to classify? (1: stim type; 2: L/R)
+model(1).add_pred = {'session','run'};
+model(1).CVstyle= {'LeaveOneRunOut'}; 
+model(1).trainConds = {'seq'};
+model(1).testConds = {'seq','onset','random'};
+model(1).cond_factor = 1; 
+model(1).color = 'r'; 
+model(1).sym = 's';
+model(1).figname = 'Classify L/R, train: seq';
+
+model(2).desc = {'DiscrimType', 'linear', 'OptimizeHyperparameters', 'none'};
+model(2).class_factor = 1; % which factor are you trying to classify? (1: stim type; 2: L/R)
+model(2).add_pred = {'session','run'};
+model(2).CVstyle= {'LeaveOneRunOut'}; 
+% model(2).CVstyle= {'Kfold',10}; % can do Kfold if train and test conds are the same
+model(2).trainConds = {'seq','onset','random'};
+model(2).testConds = {'seq','onset','random'};
+model(2).cond_factor = 1; 
+model(2).color = 'b'; 
+model(2).sym = 'o';
+x_lim = [0 4];
+x_chance = min(x_lim):max(x_lim);
+model(2).figname = 'Classify StimType, train: all';
+
+for m = 1:2
+    
+    figure('NumberTitle', 'off', 'Name', model(m).figname);
+    
+    for r = 1:3
+        
+        % generate predictors 
+        % if not adding factors, then this should work: predictors = roi(r).predictors;         
+        predictors = mvpa.generate_predictors(model(m), factor, roi(r)); % add additional factors (e.g., run/sessions)
+        predictors = cell2mat(predictors);
+        
+        % partition data for cross validation
+        [cv, doi, doiPredictors] = mvpa.select_train_test(model(m), factor, predictors);
+        
+        % initialize
+        testlabels_all = [];
+        predlabels_all = [];
+        coi_all = [];
+        
+        % train and test 
+        for run = 1:cv.NumTestSets % run will be the test set
+            
+            % get train and test sets
+            train_idx = cv.training(run);
+            test_idx = cv.test(run);
+            trainlabels = doi(model(m).class_factor).doilabels(train_idx);
+            testlabels = doi(model(m).class_factor).doilabels(test_idx);
+            coi = doi(model(m).cond_factor).doilabels(test_idx);
+            
+            % train
+            Mdl = mvpa.train(model(m), doiPredictors(train_idx,:), trainlabels);
+            
+            % test
+            predlabels = mvpa.test(Mdl, doiPredictors(test_idx,:));
+            testlabels_all = [testlabels_all; testlabels];
+            predlabels_all = [predlabels_all; predlabels];
+            coi_all = [coi_all; coi];
+        end
+        
+        % get performance and plot
+        for c = 1:length(model(m).testConds)
+            condidx = strcmp(coi_all,model(m).testConds{c});
+            results(c) = mvpa.output(testlabels_all(condidx), predlabels_all(condidx));
+            subplot(1,3,r);
+            h = errorbar(c, results(c).mean, results(c).sem, model(m).sym); hold on;
+            set(h, 'MarkerEdgeColor', model(m).color, 'MarkerFaceColor', model(m).color, 'Color', model(m).color); 
+        end
+        plot(x_chance, repmat(factor(model(m).class_factor).chance,size(x_chance)), 'k--');
+        set(gca, 'XLim', x_lim)
+        set(gca, 'YLim', [0 1])
+        title(roi(r).name);
+        xlabel('conditions')
+    end
+end
+
+
+


### PR DESCRIPTION
1) separated classification functions out
2) generate_predictors: made the numbers in 'predictors' single -- makes it possible to make predictors a matrix when putting into the training functions
3) added function for leave one run out 